### PR TITLE
feat: add Cloudflare D1 schema and database helper (#1)

### DIFF
--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,66 @@
+-- SFScrim 初期スキーマ
+-- 参照: docs/sfl-rules.md / Issue #1
+--
+-- 設計メモ:
+--  - 各 ID は UUIDv4 を想定（アプリ層で発行）。SQLite の AUTOINCREMENT は使わない。
+--  - timestamps は unix epoch（秒）。SQLite の `unixepoch()` で生成。
+--  - SFL ルール上の定数値（先取 pt 等）はここに保存しない。設定値（src/config）参照。
+--  - matches.points は「その対戦で実際に動いたポイント数」を記録（履歴用）。
+--    ルール定数のスナップショットではなく、計算結果を入れる。
+
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  provider      TEXT NOT NULL CHECK (provider IN ('google', 'discord')),
+  provider_id   TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  avatar_url    TEXT,
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+  UNIQUE (provider, provider_id)
+);
+
+CREATE TABLE scrims (
+  id            TEXT PRIMARY KEY,
+  owner_id      TEXT REFERENCES users(id) ON DELETE SET NULL,
+  format        TEXT NOT NULL CHECK (format IN ('regular', 'playoff', 'final')),
+  status        TEXT NOT NULL CHECK (status IN ('draft', 'in_progress', 'finished')),
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX idx_scrims_owner_id ON scrims(owner_id);
+CREATE INDEX idx_scrims_status ON scrims(status);
+
+CREATE TABLE teams (
+  id              TEXT PRIMARY KEY,
+  scrim_id        TEXT NOT NULL REFERENCES scrims(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  side            TEXT NOT NULL CHECK (side IN ('home', 'away')),
+  order_position  INTEGER NOT NULL CHECK (order_position BETWEEN 1 AND 3),
+  UNIQUE (scrim_id, side)
+);
+-- scrim_id 単独の検索は UNIQUE(scrim_id, side) の leftmost prefix でカバーされる
+
+CREATE TABLE players (
+  id          TEXT PRIMARY KEY,
+  team_id     TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  position    TEXT NOT NULL CHECK (position IN ('vanguard', 'midfield', 'champion', 'sub')),
+  character   TEXT
+);
+
+CREATE INDEX idx_players_team_id ON players(team_id);
+
+CREATE TABLE matches (
+  id              TEXT PRIMARY KEY,
+  scrim_id        TEXT NOT NULL REFERENCES scrims(id) ON DELETE CASCADE,
+  round_no        INTEGER NOT NULL CHECK (round_no >= 1),
+  position        TEXT NOT NULL CHECK (position IN ('vanguard', 'midfield', 'champion', 'tiebreak')),
+  winner_team_id  TEXT REFERENCES teams(id) ON DELETE SET NULL,
+  points          INTEGER NOT NULL CHECK (points >= 0),
+  created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX idx_matches_scrim_round_position ON matches(scrim_id, round_no, position);
+-- winner_team_id は ON DELETE SET NULL のため参照側スキャン回避用に index を張る
+CREATE INDEX idx_matches_winner_team_id ON matches(winner_team_id);
+-- scrim_id 単独の検索は idx_matches_scrim_round_position の leftmost prefix でカバーされる

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "typecheck": "tsc --noEmit",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
+    "db:migrate:dev": "wrangler d1 migrations apply sfscrim-db --local",
+    "db:migrate:prod": "wrangler d1 migrations apply sfscrim-db --remote",
+    "db:execute:dev": "wrangler d1 execute sfscrim-db --local"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.19.4",
@@ -20,6 +23,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@opennextjs/cloudflare':
         specifier: ^1.19.4
-        version: 1.19.4(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.85.0)
+        version: 1.19.4(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -24,6 +24,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260426.1
+        version: 4.20260426.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.4
@@ -50,7 +53,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: ^4.85.0
-        version: 4.85.0
+        version: 4.85.0(@cloudflare/workers-types@4.20260426.1)
 
 packages:
 
@@ -428,6 +431,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260426.1':
+    resolution: {integrity: sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4552,6 +4558,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260424.1':
     optional: true
 
+  '@cloudflare/workers-types@4.20260426.1': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5042,7 +5050,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.19.4(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.85.0)':
+  '@opennextjs/cloudflare@1.19.4(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
@@ -5054,7 +5062,7 @@ snapshots:
       glob: 12.0.0
       next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-tqdm: 0.8.6
-      wrangler: 4.85.0
+      wrangler: 4.85.0(@cloudflare/workers-types@4.20260426.1)
       yargs: 18.0.0
     transitivePeerDependencies:
       - aws-crt
@@ -7930,7 +7938,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260424.1
       '@cloudflare/workerd-windows-64': 1.20260424.1
 
-  wrangler@4.85.0:
+  wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
@@ -7941,6 +7949,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260424.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260426.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,11 @@
+import type { D1Database, Fetcher } from "@cloudflare/workers-types";
+
+declare global {
+  interface CloudflareEnv {
+    DB: D1Database;
+    ASSETS: Fetcher;
+    APP_ENV: string;
+  }
+}
+
+export {};

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,47 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import type { D1Database, D1Result } from "@cloudflare/workers-types";
+
+export async function getDb(): Promise<D1Database> {
+  const { env } = await getCloudflareContext();
+  if (!env.DB) {
+    throw new Error(
+      "D1 binding 'DB' is not available. Check wrangler.jsonc d1_databases config.",
+    );
+  }
+  return env.DB;
+}
+
+export async function queryAll<T>(
+  sql: string,
+  params: ReadonlyArray<string | number | null> = [],
+): Promise<T[]> {
+  const db = await getDb();
+  const result: D1Result<T> = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<T>();
+  return result.results ?? [];
+}
+
+export async function queryFirst<T>(
+  sql: string,
+  params: ReadonlyArray<string | number | null> = [],
+): Promise<T | null> {
+  const db = await getDb();
+  const row = await db
+    .prepare(sql)
+    .bind(...params)
+    .first<T>();
+  return row ?? null;
+}
+
+export async function execute(
+  sql: string,
+  params: ReadonlyArray<string | number | null> = [],
+): Promise<void> {
+  const db = await getDb();
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run();
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,11 +11,16 @@
   "observability": {
     "enabled": true
   },
+  // Cloudflare D1 (SQLite) binding.
+  // ローカル開発は `--local` で動作するため database_id は placeholder のままで OK。
+  // 本番デプロイ前に `pnpm wrangler d1 create sfscrim-db` を実行し、
+  // 出力された database_id をここに貼り替える。
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "sfscrim-db",
-      "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE"
+      "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE",
+      "migrations_dir": "migrations"
     }
   ],
   "vars": {


### PR DESCRIPTION
Closes #1

## Summary
- `migrations/0001_init.sql` で SFScrim の初期スキーマ（users / scrims / teams / players / matches）を定義。CHECK 制約・FK・適切な index を付与。
- `src/lib/db.ts` に型付き D1 ヘルパ（`getDb` / `queryAll` / `queryFirst` / `execute`）を追加。
- `src/env.d.ts` で `CloudflareEnv` を宣言、`getCloudflareContext()` の型推論で `env.DB` が型付きで取れるように。
- `wrangler.jsonc` に `migrations_dir: "migrations"` を追加。
- `package.json` に `db:migrate:dev` / `db:migrate:prod` / `db:execute:dev` を追加。
- devDependency に `@cloudflare/workers-types` を追加（`D1Database` / `Fetcher` の型のため）。

## 設計判断
- **ID**: アプリ層で UUIDv4 を発行する前提（`AUTOINCREMENT` は使わない）。
- **timestamps**: unix epoch 秒（`unixepoch()` デフォルト）。
- **SFL ルール定数の扱い**: `matches.points` は「実際に動いた pt」を記録する履歴列で、ルール定数（10/10/20/70/90 等）はここに保存しない。`docs/sfl-rules.md` に従い、設定値として外出しする方針（後続 issue で `src/config/` に集約予定）。
- **index 設計**: `UNIQUE(scrim_id, side)` および `UNIQUE(scrim_id, round_no, position)` の leftmost prefix で `scrim_id` 単独検索もカバーできるため冗長 index は外した。`matches.winner_team_id` は `ON DELETE SET NULL` のため参照側スキャン回避用に index を張った。

## Verification
- `pnpm db:migrate:dev` 成功
- `pnpm wrangler d1 execute sfscrim-db --local --command "SELECT 1"` 成功
- 全テーブル作成と index 構成を `sqlite_master` で確認
- `pnpm lint` / `pnpm typecheck` / `pnpm build` すべて成功

## 本番デプロイ前の TODO
受け入れ基準のうち `wrangler d1 create sfscrim-db` は Cloudflare アカウントへの実リソース作成のためこの PR では実行していません。merge 後にユーザー側で:
1. `pnpm wrangler d1 create sfscrim-db` を実行
2. 出力された `database_id` を `wrangler.jsonc` の placeholder に貼り替え
3. `pnpm db:migrate:prod` で本番側に migration 適用

## Test plan
- [x] `pnpm db:migrate:dev` がエラーなく適用される
- [x] `pnpm wrangler d1 execute sfscrim-db --local --command "SELECT 1"` が成功
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [ ] (本番) `wrangler d1 create sfscrim-db` 実行後 `pnpm db:migrate:prod` で適用