### PR TITLE
chore: rename /ship workflow to /ship-loop

### DIFF
--- a/.claude/commands/ship-loop.md
+++ b/.claude/commands/ship-loop.md
@@ -1,11 +1,13 @@
 ---
-name: ship
+name: ship-loop
 description: SFScrim 専用ワークフロー — simplify → PR 作成 → review ループ → approve でマージ → 次の issue へ
 ---
 
-# /ship — SFScrim ワークフロー
+# /ship-loop — SFScrim ワークフロー
 
 issue 実装が完了したら必ずこのコマンドを使う。`gh pr create` / `gh pr merge` は hook によりこのワークフロー経由でしか通らない。
+
+> ⚠️ ユーザー個人の汎用 `/ship` skill（PR 作成までで停止する別物）と区別するため、本プロジェクトでは **`/ship-loop`** という名前で運用している。`/ship` を呼ばないこと。
 
 ## 全体フロー
 
@@ -21,7 +23,7 @@ issue 実装が完了したら必ずこのコマンドを使う。`gh pr create`
 7. .claude/.review-approved マーカー書き出し
 8. gh pr merge          ← hook が .review-approved を検証して通す（→ 削除）
 9. ローカルで main を pull、issue ブランチを削除
-10. 次の open issue を選んで checkout → 実装開始（再帰的に /ship）
+10. 次の open issue を選んで checkout → 実装開始（再帰的に /ship-loop）
 11. open issue が 0 になったら停止
 ```
 
@@ -62,7 +64,7 @@ hook が `.simplify-done` を検証 → 通過 → マーカー削除。
 
 `/review` の出力を確認：
 
-- **`APPROVED` という文字列を含む** → ループを抜けて Step 7 へ
+- **`APPROVED` という文字列を含む** → ループを抜けて Step 7 へ（**ユーザーに確認を取らず即座に進む**）
 - **それ以外（指摘がある）** → 指摘内容を読み、修正コミット & push、Step 5 に戻る
 
 ループ最大回数: **5 回**。それを超えたら停止して人間の判断を仰ぐ。
@@ -109,18 +111,20 @@ BRANCH_NAME="feat/issue-${ISSUE_NUM}-$(echo "$ISSUE_TITLE" | tr ' ' '-' | tr '[:
 git checkout -b "$BRANCH_NAME"
 ```
 
-その後、issue の本文を読んで実装に着手 → 完了したら再び `/ship`。
+その後、issue の本文を読んで実装に着手 → 完了したら再び `/ship-loop`。
 
 ## 失敗時の動作
 
 - /simplify が失敗 → 停止（人間が修正）
 - /review が 5 ラウンド以上 approve しない → 停止（人間が判断）
-- gh pr create / merge が hook で blocked → /ship フローに戻ってマーカーから再発行
+- gh pr create / merge が hook で blocked → /ship-loop フローに戻ってマーカーから再発行
 - マージ衝突 → main を pull → 解消してから retry
 
-## CLAUDE への指示
+## CLAUDE への指示（厳守）
 
 - **このワークフロー以外で `gh pr create` / `gh pr merge` を呼ばない**
-- マーカーファイルを手動で作らない（必ず /ship フロー内で書き出す）
+- マーカーファイルを手動で作らない（必ず /ship-loop フロー内で書き出す）
+- **`/review` が APPROVED を返したら、ユーザー確認を待たず Step 7→8→9→10 を一気通貫で実行する**（途中で応答を返して停止しない）
 - 5 回ループしても approve が出ない場合は人間に判断を仰ぐ
 - 全 issue が完了したら停止メッセージを出して終了
+- ユーザー個人の汎用 `/ship` skill は別物。`/ship-loop` を使うこと

--- a/.claude/hooks/check-ship-marker.sh
+++ b/.claude/hooks/check-ship-marker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# SFScrim — /ship workflow enforcement hook
+# SFScrim — /ship-loop workflow enforcement hook
 # Blocks `gh pr create` and `gh pr merge` unless the corresponding
-# marker (.simplify-done / .review-approved) was written by /ship.
+# marker (.simplify-done / .review-approved) was written by /ship-loop.
 #
 # Markers:
 #   .claude/.simplify-done      → required for `gh pr create`
@@ -47,10 +47,10 @@ if [ ! -f "$marker" ]; then
 [BLOCKED] $cmd
 
 Marker not found: $marker
-You must run the /ship workflow which executes $action and writes this marker.
+You must run the /ship-loop workflow which executes $action and writes this marker.
 
 Direct \`gh pr create\` / \`gh pr merge\` is disabled to ensure quality gates run.
-Use the project-local /ship command instead.
+Use the project-local /ship-loop command instead.
 EOF
   exit 2
 fi
@@ -66,7 +66,7 @@ if [ "$age" -gt "$ttl" ]; then
 [BLOCKED] $cmd
 
 Marker expired: $marker (age: ${age}s, ttl: ${ttl}s)
-Re-run the /ship workflow to refresh.
+Re-run the /ship-loop workflow to refresh.
 EOF
   exit 2
 fi
@@ -79,7 +79,7 @@ if [ -z "$recorded_branch" ] || [ -z "$current_branch" ]; then
 [BLOCKED] $cmd
 
 Could not determine branch (recorded: '$recorded_branch', current: '$current_branch').
-Re-run the /ship workflow.
+Re-run the /ship-loop workflow.
 EOF
   exit 2
 fi
@@ -88,7 +88,7 @@ if [ "$recorded_branch" != "$current_branch" ]; then
 [BLOCKED] $cmd
 
 Marker is for branch '$recorded_branch' but current branch is '$current_branch'.
-Switch back to the correct branch or re-run /ship.
+Switch back to the correct branch or re-run /ship-loop.
 EOF
   exit 2
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,11 @@
 
 ## 🚢 開発ワークフロー（最重要・必読）
 
-**issue 実装後は必ず `/ship` コマンドを使う。`gh pr create` / `gh pr merge` の直接実行は hook で禁止されている。**
+**issue 実装後は必ず `/ship-loop` コマンドを使う。`gh pr create` / `gh pr merge` の直接実行は hook で禁止されている。**
 
-### `/ship` の流れ
+> ⚠️ ユーザー個人の汎用 `/ship` skill（PR 作成までで停止する別物）と区別するため、本プロジェクトでは **`/ship-loop`** を使う。`/ship` を呼ぶと個人版が起動して merge → 次 issue checkout まで進まないので注意。
+
+### `/ship-loop` の流れ
 
 ```
 /simplify → commit & push → PR 作成 → /review ループ
@@ -21,18 +23,20 @@
                                        └ 指摘あり → 修正 → /review
 ```
 
-詳細は `.claude/commands/ship.md` を参照。
+詳細は `.claude/commands/ship-loop.md` を参照。
 
 ### 強制力（hook）
 
 - `.claude/settings.json` の PreToolUse hook が `gh pr create` / `gh pr merge` を監視
 - マーカーファイル（`.claude/.simplify-done` / `.claude/.review-approved`）が無い・期限切れ・branch 不一致 なら BLOCK
-- マーカーは `/ship` フロー内でのみ発行される
+- マーカーは `/ship-loop` フロー内でのみ発行される
 - 直接 `gh pr create` を叩くと exit 2 で止まる
 
 ### 連続ループ
 
-`/ship` は完了後、自動で次の open issue を checkout して再帰的に走る。**open issue が 0 件になったら停止**。
+`/ship-loop` は完了後、自動で次の open issue を checkout して再帰的に走る。**open issue が 0 件になったら停止**。
+
+**重要**: `/review` が APPROVED を返したら、ユーザーに確認を取らず Step 7（承認マーカー）→ Step 8（merge）→ Step 9（main pull）→ Step 10（次 issue checkout & 実装着手）まで一気通貫で進める。途中で応答を返して停止しない。
 
 ### 二段防御
 


### PR DESCRIPTION
## Summary
- `.claude/commands/ship.md` → `ship-loop.md` にリネーム（frontmatter の `name` も同期）
- `CLAUDE.md` / `.claude/hooks/check-ship-marker.sh` 内の `/ship` 参照を `/ship-loop` に置換
- `ship-loop.md` の Step 6 / 「CLAUDE への指示」節に **APPROVED 後はユーザー確認なく Step 7→8→9→10 を一気通貫で実行** を明記

## なぜ
Issue #1 のフロー実行時、Skill ツールで `/ship` を呼ぶとユーザー個人の汎用 `ship` skill（PR 作成までで停止）が起動し、プロジェクト固有のフロー（merge → 次 issue checkout）に自動接続されない問題が発生。プロジェクト側のコマンド名を `/ship-loop` に変えて衝突を物理的に解消する。

## 影響範囲
- ドキュメント / フック内コメント / コマンド名のみ。アプリコード変更なし。
- マーカー名（`.claude/.simplify-done` / `.claude/.review-approved`）と hook ロジックは不変。
- 既存ブランチ・PR への影響なし。

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] grep で `/ship-loop` 以外の `/ship` 参照ゼロを確認
- [x] Skill 一覧に `ship-loop` として認識されていることを確認