### PR TITLE
ci: add Cloudflare Workers deploy workflow with DEPLOY_ENABLED gate (#2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  workflow_dispatch:
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -40,7 +39,13 @@ jobs:
 
   deploy-preview:
     name: Deploy (Preview)
-    if: github.event_name == 'pull_request' && vars.DEPLOY_ENABLED == 'true'
+    # fork からの PR は secrets を取得できず確実に fail する（GitHub 仕様）。
+    # ノイズ回避と将来 pull_request_target へ切り替えた際の安全性のため、
+    # 同一リポジトリ内の PR のみに限定する。
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,80 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-prod:
+    name: Deploy (Production)
+    # 本番 secrets / D1 ID / DEPLOY_ENABLED が揃うまではスキップ。
+    # docs/deployment.md の手順を実施した後 vars.DEPLOY_ENABLED = "true" にすると有効化される。
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build (OpenNext for Cloudflare)
+        run: pnpm exec opennextjs-cloudflare build
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+
+  deploy-preview:
+    name: Deploy (Preview)
+    if: github.event_name == 'pull_request' && vars.DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build (OpenNext for Cloudflare)
+        run: pnpm exec opennextjs-cloudflare build
+      - name: Upload preview version
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions upload --message "PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.sha }})"
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.preview.outputs.deployment-url }}`;
+            const body = url
+              ? `🚀 Preview deployed: ${url}`
+              : `🚀 Preview version uploaded. Check Cloudflare dashboard for the URL.`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@
 ## ドキュメント構成
 
 - `docs/sfl-rules.md` — SFL 公式ルールまとめ（実装の根拠）
+- `docs/deployment.md` — Cloudflare Workers デプロイ手順（初回セットアップ含む）
 - `docs/architecture.md` — システム構成（作成予定）
 - `docs/api.md` — API 仕様（作成予定）
 - `docs/feature-spec/` — 機能ごとの仕様書（作成予定）

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,128 @@
+# SFScrim デプロイ手順
+
+SFScrim は **Cloudflare Workers** にデプロイされます（`@opennextjs/cloudflare` 経由）。本ドキュメントは初回セットアップから本番運用までの手順をまとめたものです。
+
+> ℹ️ Issue タイトルでは「Cloudflare Pages」と表記されている箇所がありますが、`wrangler.jsonc` / `open-next.config.ts` の構成上、デプロイ先は Workers (with assets binding) です。
+
+---
+
+## 構成概要
+
+```
+GitHub push (main) ──▶ .github/workflows/deploy.yml
+                       └─ deploy-prod    ──▶ wrangler deploy        ──▶ Cloudflare Workers (本番)
+GitHub PR open    ──▶ .github/workflows/deploy.yml
+                       └─ deploy-preview ──▶ wrangler versions upload ──▶ Cloudflare Workers (プレビュー)
+                                                                          └─ PR にコメントで preview URL 通知
+```
+
+| ジョブ | トリガー | 動作 |
+|---|---|---|
+| `deploy-prod` | `push` to `main` | `pnpm exec opennextjs-cloudflare build` → `wrangler deploy` |
+| `deploy-preview` | `pull_request` | 上記 build → `wrangler versions upload` → preview URL を PR にコメント |
+
+両ジョブとも **`vars.DEPLOY_ENABLED == 'true'`** が無いとスキップされます（ガード）。
+
+---
+
+## 初回セットアップ（手動）
+
+### 1. Cloudflare API token を作成
+
+Cloudflare ダッシュボード → My Profile → API Tokens → **Create Token**
+
+「Edit Cloudflare Workers」テンプレートをベースに、以下の権限を含む token を作成：
+
+- **Account** → Workers Scripts → Edit
+- **Account** → D1 → Edit
+- **Account** → Account Settings → Read（Account ID 検証用）
+
+→ 生成された token を控える（再表示できない）。
+
+### 2. Cloudflare Account ID を取得
+
+Workers & Pages ダッシュボード右側のサイドバー、または以下で取得：
+
+```bash
+pnpm wrangler whoami
+```
+
+### 3. GitHub Secrets / Variables を設定
+
+リポジトリの Settings → Secrets and variables → Actions:
+
+**Secrets**:
+- `CLOUDFLARE_API_TOKEN` = （手順 1 の token）
+- `CLOUDFLARE_ACCOUNT_ID` = （手順 2 の Account ID）
+
+**Variables**:
+- `DEPLOY_ENABLED` = `true`
+
+> `DEPLOY_ENABLED` を未設定 / `false` のままにしておくと、deploy.yml は何もしない状態を維持します（CI 履歴が無駄に汚れない）。
+
+### 4. D1 本番データベースを作成
+
+```bash
+pnpm wrangler d1 create sfscrim-db
+```
+
+出力された `database_id` を `wrangler.jsonc` の `PLACEHOLDER_RUN_WRANGLER_D1_CREATE` に置き換える：
+
+```diff
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "sfscrim-db",
+-     "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE",
++     "database_id": "<手順 4 で出力された UUID>",
+      "migrations_dir": "migrations"
+    }
+  ],
+```
+
+その上で本番 migration を適用：
+
+```bash
+pnpm db:migrate:prod
+```
+
+### 5. 初回デプロイ確認
+
+ローカルから手動で deploy を試す（任意）:
+
+```bash
+pnpm run deploy
+```
+
+成功したら、`DEPLOY_ENABLED = true` を設定した状態で main に変更を push。GitHub Actions の `deploy-prod` が走り、Cloudflare Workers にデプロイされる。
+
+---
+
+## ローカル開発・プレビュー
+
+```bash
+# OpenNext 経由で Workers エミュレーションを起動
+pnpm preview
+```
+
+D1 の local instance（`.wrangler/state/v3/d1/`）を使うので、本番 DB に影響しない。
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因 / 対処 |
+|---|---|
+| GitHub Actions の deploy ジョブが起動しない | `vars.DEPLOY_ENABLED` が `true` になっているか確認 |
+| `Authentication error` | `CLOUDFLARE_API_TOKEN` の権限不足。Workers Scripts:Edit / D1:Edit を再確認 |
+| `D1_ERROR: no such database` | `wrangler.jsonc` の `database_id` が placeholder のまま、または本番 migration 未適用 |
+| Preview URL が PR にコメントされない | `wrangler-action` の `deployment-url` output は `versions upload` で常に取得できるとは限らない。Cloudflare ダッシュボード → Workers & Pages → 該当 Worker → Versions から確認 |
+
+---
+
+## 関連ファイル
+
+- `.github/workflows/deploy.yml` — デプロイワークフロー
+- `wrangler.jsonc` — Cloudflare 設定
+- `open-next.config.ts` — OpenNext 設定
+- `migrations/` — D1 schema migration


### PR DESCRIPTION
Closes #2
Spawns #19 (manual setup follow-up)

## Summary
- `.github/workflows/deploy.yml` を追加：
  - `deploy-prod`: main push で `wrangler deploy`（本番）
  - `deploy-preview`: PR で `wrangler versions upload` → preview URL を PR コメント
- 両ジョブとも **`vars.DEPLOY_ENABLED == 'true'`** が必須。secrets / D1 本番 ID が揃うまでは全スキップでクリーン。
- 既存の必須 CI (`ci.yml` lint/typecheck/build) からは独立。deploy.yml が fail してもマージはブロックされない（main 保護は `ci.yml` のみ要求）。
- `docs/deployment.md` に Cloudflare 側初回セットアップ手順を整理（API token / Account ID / Secrets / Variables / D1 作成 / database_id 差し替え）。
- `CLAUDE.md` のドキュメント構成に `deployment.md` を追記。

## なぜ Pages ではなく Workers
Issue タイトルは「Cloudflare Pages CI/CD」だが、本リポジトリは `@opennextjs/cloudflare` + `wrangler.jsonc` + `.open-next/worker.js` 構成で、デプロイ先は **Cloudflare Workers (with assets binding)**。Pages にはデプロイできないため Workers 前提で実装。`docs/deployment.md` 冒頭にも明記。

## DEPLOY_ENABLED ガードの意図
secrets / 本番 D1 ID が未設定の状態で deploy ジョブを走らせると確実に fail する。CI 履歴を汚さないため、GitHub Repository Variable `DEPLOY_ENABLED = 'true'` を明示的に立てるまで全ジョブを skip する設計。

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
```

## 手動セットアップ（merge 後）
本 PR では実 deploy できない。Cloudflare アカウント側 / GitHub 側の手動手順を **#19** に切り出した：

1. Cloudflare API token 作成（Workers Scripts:Edit / D1:Edit）
2. GitHub Secrets / Variables 設定
3. `wrangler d1 create sfscrim-db` → `wrangler.jsonc` の placeholder 差し替え（PR で）
4. `pnpm db:migrate:prod`
5. `DEPLOY_ENABLED=true` を立てて初回 deploy 確認

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `deploy.yml` の YAML 構文目視確認（`vars.DEPLOY_ENABLED` ガード / cloudflare/wrangler-action@v3 引数）
- [x] `docs/deployment.md` で手順カバー範囲を確認
- [ ] (#19 で実施) `DEPLOY_ENABLED=true` 状態で本 PR の deploy-preview ジョブが green になり preview URL がコメントされる
- [ ] (#19 で実施) main merge 時に deploy-prod が green、Cloudflare Workers にデプロイされる