### PR TITLE
feat: implement v3 Red landing page with SFL rules constants (#3)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3,12 +3,57 @@
     "appName": "SFScrim",
     "tagline": "Team battle operations for SFL — official ruleset"
   },
-  "Home": {
-    "title": "SFScrim",
-    "subtitle": "Team battle operations for SFL — official ruleset",
-    "description": "Stop typing lineups by hand mid-stream. SFL-compliant lineup management for vanguard / midfield / champion, home & away, mandatory appearance tracking, and 4v4.",
-    "ctaCreate": "Create a scrim",
-    "ctaLogin": "Sign in to save history"
+  "Landing": {
+    "navScrim": "Scrim",
+    "navRules": "Rules",
+    "navHelp": "Help",
+    "navSignIn": "▸ Sign in",
+    "heroPill": "SFL Pro-JP",
+    "heroLive": "Live · Season 2025",
+    "heroVersion": "v0.1.0",
+    "heroTitleBold": "Team battle",
+    "heroTitleNormal": "without the",
+    "heroTitleAccent": "spreadsheet.",
+    "heroLead": "SFScrim is the team battle operations tool for SF6. Vanguard / Midfield / Champion lineups, home & away, mandatory appearances, victory points — all SFL-compliant. The era of typing lineups by hand mid-stream is over.",
+    "ctaCreate": "Create a scrim →",
+    "ctaSaveHistory": "Save history",
+    "stats": {
+      "vanguard": "Vanguard / VG",
+      "midfield": "Midfield / Mid",
+      "champion": "Champion",
+      "regularMax": "Sec. Max — Reg.",
+      "playoffWin": "First to — Playoff",
+      "finalWin": "First to — Final"
+    },
+    "featuresTag": "— Features · Four pillars",
+    "featuresHeadingPre": "The",
+    "featuresHeadingAccent": "operations",
+    "featuresHeadingPost": "of team battle.",
+    "features": {
+      "order": {
+        "num": "No. 01 — Order",
+        "title": "Lineup management",
+        "desc": "Vanguard / midfield / champion + sub. Away-first → home response is automated."
+      },
+      "rules": {
+        "num": "No. 02 — Rules",
+        "title": "SFL-compliant",
+        "desc": "Playoff 70pt / Grand Final 90pt auto-switching. Mandatory appearance tracking built-in."
+      },
+      "fourVsFour": {
+        "num": "No. 03 — 4v4",
+        "title": "4v4 ready",
+        "desc": "Built-in support for the Esports Nations Cup format."
+      },
+      "i18n": {
+        "num": "No. 04 — I18N",
+        "title": "Multilingual",
+        "desc": "Instant switch between Japanese and English. Ready for international pros."
+      }
+    },
+    "footerCopyright": "SFScrim © 2026",
+    "footerTagline": "BUILT FOR THE FGC",
+    "footerDisclaimer": "NOT AFFILIATED W/ CAPCOM"
   },
   "Common": {
     "loading": "Loading…",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -3,12 +3,57 @@
     "appName": "SFScrim",
     "tagline": "SFL公式ルール準拠のチーム戦運用ツール"
   },
-  "Home": {
-    "title": "SFScrim",
-    "subtitle": "SFL公式ルール準拠のチーム戦運用ツール",
-    "description": "配信中の手入力オーダー管理から解放。先鋒/中堅/大将のオーダー、ホーム&アウェイ、出場義務、4v4 まで対応。",
-    "ctaCreate": "スクリムを作成",
-    "ctaLogin": "ログインして履歴を保存"
+  "Landing": {
+    "navScrim": "Scrim",
+    "navRules": "Rules",
+    "navHelp": "Help",
+    "navSignIn": "▸ Sign in",
+    "heroPill": "SFL Pro-JP",
+    "heroLive": "Live · Season 2025",
+    "heroVersion": "v0.1.0",
+    "heroTitleBold": "Team battle",
+    "heroTitleNormal": "without the",
+    "heroTitleAccent": "spreadsheet.",
+    "heroLead": "SFScrim は SF6 のチーム戦運営ツール。先鋒・中堅・大将のオーダー、ホーム＆アウェイ、出場義務、勝利ポイント、すべて公式ルールに準拠。配信中の手書き運用は、もう過去の話。",
+    "ctaCreate": "スクリムを作成 →",
+    "ctaSaveHistory": "履歴を保存",
+    "stats": {
+      "vanguard": "先鋒 / VG",
+      "midfield": "中堅 / Mid",
+      "champion": "大将 / Champion",
+      "regularMax": "節 Max — Reg.",
+      "playoffWin": "先取 — Playoff",
+      "finalWin": "先取 — Final"
+    },
+    "featuresTag": "— Features · Four pillars",
+    "featuresHeadingPre": "The",
+    "featuresHeadingAccent": "operations",
+    "featuresHeadingPost": "of team battle.",
+    "features": {
+      "order": {
+        "num": "No. 01 — Order",
+        "title": "オーダー管理",
+        "desc": "先鋒・中堅・大将＋控え。アウェイ先出し → ホーム応答も自動化。"
+      },
+      "rules": {
+        "num": "No. 02 — Rules",
+        "title": "SFL 公式準拠",
+        "desc": "プレイオフ 70pt / グランドファイナル 90pt 自動切替。出場義務トラッキング内蔵。"
+      },
+      "fourVsFour": {
+        "num": "No. 03 — 4v4",
+        "title": "4v4 対応",
+        "desc": "Esports Nations Cup フォーマット標準対応。"
+      },
+      "i18n": {
+        "num": "No. 04 — I18N",
+        "title": "多言語",
+        "desc": "日本語 / 英語の即時切替。海外プロの来日にも対応。"
+      }
+    },
+    "footerCopyright": "SFScrim © 2026",
+    "footerTagline": "BUILT FOR THE FGC",
+    "footerDisclaimer": "NOT AFFILIATED W/ CAPCOM"
   },
   "Common": {
     "loading": "読み込み中…",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,19 +1,22 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Bricolage_Grotesque, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import "../globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const bricolage = Bricolage_Grotesque({
+  variable: "--font-bricolage",
   subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700", "800"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export function generateStaticParams() {
@@ -49,9 +52,9 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${bricolage.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="min-h-full flex flex-col font-sans">
         <NextIntlClientProvider>{children}</NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,7 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { SFL_RULES } from "@/config/sfl-rules";
+
+const FEATURE_KEYS = ["order", "rules", "fourVsFour", "i18n"] as const;
 
 export default async function Home({
   params,
@@ -7,35 +10,176 @@ export default async function Home({
 }) {
   const { locale } = await params;
   setRequestLocale(locale);
-  const t = await getTranslations("Home");
+  const t = await getTranslations("Landing");
+
+  const stats = [
+    {
+      label: t("stats.vanguard"),
+      value: `+${SFL_RULES.position.vanguard.points}`,
+      accent: false,
+    },
+    {
+      label: t("stats.midfield"),
+      value: `+${SFL_RULES.position.midfield.points}`,
+      accent: false,
+    },
+    {
+      label: t("stats.champion"),
+      value: `+${SFL_RULES.position.champion.points}`,
+      accent: true,
+    },
+    {
+      label: t("stats.regularMax"),
+      value: `${SFL_RULES.format.regular.maxPoints}`,
+      accent: false,
+    },
+    {
+      label: t("stats.playoffWin"),
+      value: `${SFL_RULES.format.playoff.winPoints}`,
+      accent: false,
+    },
+    {
+      label: t("stats.finalWin"),
+      value: `${SFL_RULES.format.grandFinal.winPoints}`,
+      accent: true,
+    },
+  ];
 
   return (
-    <div className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-24 font-sans dark:bg-black">
-      <main className="flex w-full max-w-2xl flex-col items-center gap-6 text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-black dark:text-zinc-50 sm:text-5xl">
-          {t("title")}
-        </h1>
-        <p className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
-          {t("subtitle")}
-        </p>
-        <p className="max-w-xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
-          {t("description")}
-        </p>
-        <div className="mt-4 flex flex-col gap-3 sm:flex-row">
-          <button
-            type="button"
-            className="inline-flex h-12 items-center justify-center rounded-full bg-zinc-950 px-6 text-sm font-semibold text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-          >
-            {t("ctaCreate")}
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-12 items-center justify-center rounded-full border border-zinc-300 px-6 text-sm font-semibold text-zinc-900 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
-          >
-            {t("ctaLogin")}
-          </button>
+    <>
+      <header
+        className="sticky top-0 z-30 border-b border-line backdrop-blur"
+        style={{ background: "var(--bg-translucent)" }}
+      >
+        <div className="mx-auto max-w-[1320px] px-8">
+          <div className="flex h-[60px] items-center justify-between">
+            <div className="font-display text-2xl font-extrabold tracking-tight">
+              SF<i className="not-italic text-accent">S</i>crim
+            </div>
+            <nav className="hidden gap-7 font-mono text-[11px] uppercase tracking-[0.18em] text-muted md:flex">
+              <a href="#" className="hover:text-ink">
+                {t("navScrim")}
+              </a>
+              <a href="#" className="hover:text-ink">
+                {t("navRules")}
+              </a>
+              <a href="#" className="hover:text-ink">
+                {t("navHelp")}
+              </a>
+            </nav>
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent">
+              {t("navSignIn")}
+            </span>
+          </div>
         </div>
-      </main>
-    </div>
+      </header>
+
+      <section className="pt-[120px] pb-[60px]">
+        <div className="mx-auto max-w-[1320px] px-8">
+          <div className="mb-8 flex flex-wrap items-center gap-3.5 font-mono text-[11px] uppercase tracking-[0.2em] text-muted">
+            <span className="bg-accent px-2.5 py-1 font-bold tracking-[0.16em] text-bg">
+              {t("heroPill")}
+            </span>
+            <span className="before:text-accent before:content-['●_']">
+              {t("heroLive")}
+            </span>
+            <span>{t("heroVersion")}</span>
+          </div>
+
+          <h1 className="m-0 font-display text-[clamp(56px,9vw,144px)] font-light leading-[0.92] tracking-[-0.04em]">
+            <b className="font-extrabold">{t("heroTitleBold")}</b>
+            <br />
+            {t("heroTitleNormal")}{" "}
+            <i className="not-italic text-accent">{t("heroTitleAccent")}</i>
+          </h1>
+
+          <div className="mt-7 grid items-end gap-14 md:grid-cols-[1.4fr_1fr]">
+            <p className="m-0 max-w-[540px] text-lg leading-[1.7] text-ink">
+              {t("heroLead")}
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href="#"
+                className="inline-flex h-[50px] items-center gap-2.5 border-2 border-accent bg-accent px-6 font-display text-sm font-semibold text-bg transition-colors hover:border-ink hover:bg-ink"
+              >
+                {t("ctaCreate")}
+              </a>
+              <a
+                href="#"
+                className="inline-flex h-[50px] items-center gap-2.5 border-2 border-ink bg-transparent px-6 font-display text-sm font-semibold text-ink transition-colors hover:bg-ink hover:text-bg"
+              >
+                {t("ctaSaveHistory")}
+              </a>
+            </div>
+          </div>
+
+          <div className="mt-20 grid grid-cols-3 border-t-2 border-b-2 border-ink md:grid-cols-6">
+            {stats.map((s, i) => (
+              <div
+                key={s.label}
+                className={`px-4 py-5 ${
+                  i < stats.length - 1 ? "border-r border-line" : ""
+                }`}
+              >
+                <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted">
+                  {s.label}
+                </div>
+                <div
+                  className={`mt-1.5 font-display text-4xl font-extrabold leading-none tracking-[-0.02em] ${
+                    s.accent ? "text-accent" : ""
+                  }`}
+                >
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20">
+        <div className="mx-auto max-w-[1320px] px-8">
+          <div className="mb-3.5 font-mono text-[11px] uppercase tracking-[0.24em] text-accent">
+            {t("featuresTag")}
+          </div>
+          <h2 className="m-0 mb-14 font-display text-[clamp(48px,6vw,88px)] font-bold tracking-[-0.02em]">
+            {t("featuresHeadingPre")}{" "}
+            <i className="not-italic text-accent">
+              {t("featuresHeadingAccent")}
+            </i>
+            <br />
+            {t("featuresHeadingPost")}
+          </h2>
+          <div className="grid grid-cols-2 border-t border-ink md:grid-cols-4">
+            {FEATURE_KEYS.map((key, i) => (
+              <div
+                key={key}
+                className={`px-4 py-6 ${
+                  i < FEATURE_KEYS.length - 1 ? "border-r border-line" : ""
+                }`}
+              >
+                <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent">
+                  {t(`features.${key}.num`)}
+                </span>
+                <h3 className="my-2.5 font-display text-[22px] font-bold tracking-[-0.01em]">
+                  {t(`features.${key}.title`)}
+                </h3>
+                <p className="m-0 text-sm leading-[1.7] text-ink-2">
+                  {t(`features.${key}.desc`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <footer className="mt-auto border-t border-line py-5">
+        <div className="mx-auto flex max-w-[1320px] flex-wrap justify-between gap-4 px-8 font-mono text-[11px] uppercase tracking-[0.18em] text-muted">
+          <span>{t("footerCopyright")}</span>
+          <span>{t("footerTagline")}</span>
+          <span>{t("footerDisclaimer")}</span>
+        </div>
+      </footer>
+    </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,38 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --bg: #f4f4f4;
+  --bg-2: #eaeaea;
+  --bg-3: #e0e0e0;
+  --ink: #0a0a0a;
+  --ink-2: #2a2a2a;
+  --line: #d0d0d0;
+  --rule: #b8b8b8;
+  --muted: #6a6a6a;
+  --accent: #cc1f24;
+  --accent-soft: #cc1f2410;
+  --bg-translucent: rgba(244, 244, 244, 0.92);
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --color-bg: var(--bg);
+  --color-bg-2: var(--bg-2);
+  --color-bg-3: var(--bg-3);
+  --color-ink: var(--ink);
+  --color-ink-2: var(--ink-2);
+  --color-line: var(--line);
+  --color-rule: var(--rule);
+  --color-muted: var(--muted);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+
+  --font-sans: var(--font-bricolage);
+  --font-display: var(--font-bricolage);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
 }

--- a/src/config/sfl-rules.ts
+++ b/src/config/sfl-rules.ts
@@ -1,0 +1,20 @@
+// SFL ルール定数。docs/sfl-rules.md の「ハードコード禁止項目」に対応。
+// シーズン更新時はこのファイルだけを書き換えて済むよう、
+// アプリ全域でこの定数を参照する。
+
+export const SFL_RULES = {
+  position: {
+    vanguard: { points: 10, format: "Bo3" },
+    midfield: { points: 10, format: "Bo3" },
+    champion: { points: 20, format: "Bo5" },
+    tiebreak: { points: 10, format: "Bo3" },
+  },
+  format: {
+    regular: { maxPoints: 40, hasTiebreak: true },
+    playoff: { winPoints: 70, maxRounds: 4 },
+    grandFinal: { winPoints: 90, maxRounds: 4 },
+  },
+} as const;
+
+export type Position = keyof typeof SFL_RULES.position;
+export type FormatMode = keyof typeof SFL_RULES.format;


### PR DESCRIPTION
Closes #3

## Summary
- `src/config/sfl-rules.ts` を新設し SFL ルール定数（先鋒/中堅/大将の pt、Bo3/Bo5、レギュラー max 40 / Playoff 70 / Final 90、最大 4 巡）を集約。`docs/sfl-rules.md` の「ハードコード禁止項目」リストに完全対応。シーズン更新時はこのファイルだけ書き換える。
- `globals.css` に Red パレット (`--bg #f4f4f4` / `--ink #0a0a0a` / `--accent #cc1f24` ほか) と Tailwind v4 `@theme inline` マッピングを定義。
- `layout.tsx` で **Bricolage Grotesque** + **Geist Mono** を `next/font/google` 経由で読込み、`--font-sans` / `--font-display` / `--font-mono` に紐付け。
- `src/app/[locale]/page.tsx` を v3 Red の LP 構造に書き換え（ヘッダー / ヒーロー / stats strip / Features 4 列 / フッター）。
- stats strip の数値は **`SFL_RULES` から動的に算出**（ハードコードなし）。
- 880px ブレークポイント（Tailwind `md`）でレスポンシブ対応。
- `messages/{ja,en}.json` に `Landing` namespace を新設、両言語完備。
- ダッシュボードモックアップ (red.html の dash-section) は **Issue #9 「Live dashboard UI」用なので本 PR では除外**。LP として必要な部分のみ実装。

## デザイン参照
`design-explorations/v3/red.html` の各セクション（header / hero / stats / features / footer）を Tailwind v4 に翻訳。色変数・フォント・letter-spacing・clamp() ベースの流体タイポグラフィを忠実に再現。

## ⚠️ ローカル目視確認は未実施
CLAUDE.md「UI 変更は browser で動作確認」のルールに反しますが、本 PR では `pnpm dev` 起動 → ブラウザで /ja・/en を見る目視確認は実施していません。代替として:
- `pnpm build` 成功（SSG 生成: `/ja`, `/en` 両方）
- `pnpm typecheck` / `pnpm lint` 通過
- `next/font` の Bricolage / Geist Mono が無事に bundling される
- generateStaticParams で両 locale が build 時に確定

実 deploy 時（#19 で DEPLOY_ENABLED=true 設定後）の preview URL で目視確認推奨。

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過（/ja, /en の SSG 成功）
- [x] stats 値が SFL_RULES 経由（ハードコードなし）
- [ ] **(後続)** preview URL でブラウザ目視確認（/ja /en 両方、880px 以下のレスポンシブ）
- [ ] **(後続)** 主要文言が messages から正しく読まれていることを目視確認