### PR TITLE
chore: bind production D1 database_id and apply migration (#19 partial)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,14 +12,13 @@
     "enabled": true
   },
   // Cloudflare D1 (SQLite) binding.
-  // ローカル開発は `--local` で動作するため database_id は placeholder のままで OK。
-  // 本番デプロイ前に `pnpm wrangler d1 create sfscrim-db` を実行し、
-  // 出力された database_id をここに貼り替える。
+  // ローカルは `--local` で .wrangler/state/v3/d1 配下の SQLite を使う。
+  // 本番 ID は `wrangler d1 create sfscrim-db` で発行済（APAC region）。
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "sfscrim-db",
-      "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE",
+      "database_id": "9f54f5e0-e01d-44c6-a063-62320a76fd0e",
       "migrations_dir": "migrations"
     }
   ],


### PR DESCRIPTION
Partial: #19

## Summary
本番 D1 をセットアップし、`wrangler.jsonc` の placeholder を実 ID に差し替え。本番 D1 に `0001_init.sql` migration も適用済。

## 実行済み（CLI）
- ✅ `wrangler d1 create sfscrim-db` → `database_id = 9f54f5e0-e01d-44c6-a063-62320a76fd0e`（APAC region）
- ✅ `wrangler.jsonc` の placeholder を実 ID に差し替え
- ✅ `pnpm db:migrate:prod` で本番 D1 に `0001_init.sql` を適用、`users / scrims / teams / players / matches` 全テーブル + index を確認
- ✅ GitHub Secret `CLOUDFLARE_ACCOUNT_ID` を登録済（値: wrangler whoami から取得した Account ID）

## 残作業（ユーザー手動）
本 PR merge 後、以下を順に実施してください:

1. **Cloudflare ダッシュボードで API token を作成**
   - 権限: `Workers Scripts:Edit` / `D1:Edit` / `Account Settings:Read`
2. **`gh secret set CLOUDFLARE_API_TOKEN --body "<token>"`**
3. **`gh variable set DEPLOY_ENABLED --body "true"`**（必ず secret 設定後、先に true にすると deploy ジョブが secrets 無しで fail する）

実施後、main への push で `deploy-prod`、PR で `deploy-preview` ジョブが green になるはず。

## diff
```diff
- "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE",
+ "database_id": "9f54f5e0-e01d-44c6-a063-62320a76fd0e",
```

## simplify
ドキュメント / 設定変更のみのため Step 1 例外節（ship-loop.md）に従い `/simplify` Skill は省略。

## Test plan
- [x] `pnpm wrangler d1 create sfscrim-db` 成功
- [x] `pnpm db:migrate:prod` 成功
- [x] 本番 D1 に全テーブル (`users / scrims / teams / players / matches`) 作成済
- [x] `pnpm build` 通過
- [ ] (#19 残) Cloudflare API token 作成 → `gh secret set CLOUDFLARE_API_TOKEN`
- [ ] (#19 残) `gh variable set DEPLOY_ENABLED true`
- [ ] (#19 残) main push で deploy-prod ジョブ green