### PR TITLE
chore: introduce develop branch + dev deployment environment

### DIFF
--- a/.claude/commands/ship-loop.md
+++ b/.claude/commands/ship-loop.md
@@ -9,6 +9,20 @@ issue 実装が完了したら必ずこのコマンドを使う。`gh pr create`
 
 > ⚠️ ユーザー個人の汎用 `/ship` skill（PR 作成までで停止する別物）と区別するため、本プロジェクトでは **`/ship-loop`** という名前で運用している。`/ship` を呼ばないこと。
 
+## 🌳 ブランチ運用（本番リリース後）
+
+本番リリース済のため、開発フローは Git Flow ベースの 2 段階:
+
+```
+feature/* / chore/* / fix/*  ← develop から切る
+        ↓ PR (base: develop)
+     develop  ← merge で開発環境 (sfscrim-dev.sf6.workers.dev) に自動デプロイ
+        ↓ PR (base: main, 本番反映タイミングで手動)
+       main   ← merge で本番 (sfscrim.sf6.workers.dev) に自動デプロイ
+```
+
+**ship-loop 中の base ブランチは常に `develop`**。`main` への merge は本番リリースタイミングで人間が判断（複数 develop の変更を 1 本にまとめて main に上げる運用も可）。
+
 ## 🛑 最重要：Claude が止まりやすい節目
 
 過去の運用で **「Skill ツールから戻った直後にテキスト応答を返してターン終了」** という失敗が複数回発生している。これは ship-loop が「自動継続」を期待しているのに、Skill 戻りが「ターンの自然な終端」になることで Claude が止まる罠。
@@ -26,15 +40,15 @@ issue 実装が完了したら必ずこのコマンドを使う。`gh pr create`
 1. /simplify でコード整形・冗長削除（変更が UI/機能なら必須、ドキュメント/CI 設定のみなら省略可）
 2. コミット & push
 3. Write tool で .claude/.simplify-done に現ブランチ名を書き込み
-4. gh pr create        ← hook が .simplify-done を検証して通す（→ 削除）
+4. gh pr create --base develop  ← hook が .simplify-done を検証して通す（→ 削除）
 5. Bash で gh pr diff + gh pr view → メインターン内で self-review（Skill /review は使わない）
 6. レビュー判定:
    ├ "APPROVED" → break、即 Step 7 へ（応答テキスト返さない）
    └ 指摘あり → 修正 Edit/Write/Bash を即座に実行 → コミット → push → Step 5 に戻る（応答テキスト返さない）
 7. Write tool で .claude/.review-approved に現ブランチ名を書き込み
 8. gh pr merge --squash --delete-branch  ← hook が .review-approved を検証して通す（→ 削除）
-9. ローカルで main を pull、issue ブランチを削除
-10. 次の open issue を選んで checkout → 実装開始（再帰的に /ship-loop）
+9. ローカルで develop を pull、issue ブランチを削除
+10. 次の open issue を選んで develop から checkout → 実装開始（再帰的に /ship-loop）
 11. open issue が 0 になったら停止
 ```
 
@@ -80,8 +94,10 @@ Write(file_path: ".claude/.simplify-done", content: "<branch-name>\n")
 ### Step 4: PR 作成
 
 ```bash
-gh pr create --title "<title>" --body "<body>"
+gh pr create --base develop --title "<title>" --body "<body>"
 ```
+
+**`--base develop` を必ず指定**。デフォルト base は main なので忘れると本番直行 PR になってしまう。
 
 hook が `.simplify-done` を検証 → 通過 → マーカー削除。
 
@@ -124,8 +140,8 @@ hook が `.review-approved` を検証 → 通過 → マーカー削除。
 ### Step 9: ローカル整理
 
 ```bash
-git checkout main
-git pull origin main
+git checkout develop
+git pull origin develop
 git branch -d <feature-branch>   # 既に消えていればエラー無視で OK
 ```
 
@@ -138,17 +154,27 @@ gh issue list --state open --json number,title --jq 'sort_by(.number) | .[0]'
 0 件なら停止メッセージを出して終了。あれば:
 
 ```bash
-git checkout -b "feat/issue-<番号>-<slug>"
+git checkout -b "feat/issue-<番号>-<slug>"   # develop から派生
 ```
 
 issue 本文を読んで実装に着手 → 完了したら再び `/ship-loop`。
+
+### 本番反映（develop → main、ship-loop の対象外）
+
+`ship-loop` は **develop までで完結**。develop に蓄積した変更を本番に反映するときは、別途人間が判断してこの PR を作る:
+
+```bash
+gh pr create --base main --head develop --title "release: <date or summary>" --body "<release notes>"
+```
+
+merge すると main に push が走り、`deploy.yml` の `deploy-prod` ジョブが本番デプロイを実行。
 
 ## 失敗時の動作
 
 - /simplify が失敗 → 停止（人間が修正）
 - self-review が 5 ラウンド以上 approve しない → 停止（人間が判断）
 - gh pr create / merge が hook で blocked → /ship-loop フローに戻ってマーカーから再発行
-- マージ衝突 → main を pull → 解消してから retry
+- マージ衝突 → develop を pull → 解消してから retry
 - 受け入れ基準が Cloudflare アカウント等の外部リソース操作を要求 → ローカルで完結する範囲を実装し、外部操作を別 issue に切り出す（例: #19）
 
 ## CLAUDE への指示（厳守）

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
 
 concurrency:
@@ -12,8 +12,8 @@ concurrency:
 jobs:
   deploy-prod:
     name: Deploy (Production)
-    # 本番 secrets / D1 ID / DEPLOY_ENABLED が揃うまではスキップ。
-    # docs/deployment.md の手順を実施した後 vars.DEPLOY_ENABLED = "true" にすると有効化される。
+    # main への push で本番 (sfscrim.sf6.workers.dev) にデプロイ。
+    # vars.DEPLOY_ENABLED = "true" + secrets が揃っていることが条件。
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -30,18 +30,44 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build (OpenNext for Cloudflare)
         run: pnpm exec opennextjs-cloudflare build
-      - name: Deploy to Cloudflare Workers
+      - name: Deploy to Cloudflare Workers (production)
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
 
+  deploy-dev:
+    name: Deploy (Development)
+    # develop への push で開発環境 (sfscrim-dev.sf6.workers.dev) にデプロイ。
+    # 本番 D1 とは別の sfscrim-db-dev に向くので、データ汚染なし。
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && vars.DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build (OpenNext for Cloudflare)
+        run: pnpm exec opennextjs-cloudflare build
+      - name: Deploy to Cloudflare Workers (development)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --env development
+
   deploy-preview:
     name: Deploy (Preview)
-    # fork からの PR は secrets を取得できず確実に fail する（GitHub 仕様）。
-    # ノイズ回避と将来 pull_request_target へ切り替えた際の安全性のため、
-    # 同一リポジトリ内の PR のみに限定する。
+    # PR ごとに versions upload で preview URL を発行。
+    # fork からの PR は secrets を取得できず確実に fail するので除外。
     if: |
       github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,22 @@
 
 **issue 実装後は必ず `/ship-loop` コマンドを使う。`gh pr create` / `gh pr merge` の直接実行は hook で禁止されている。**
 
+### ブランチ運用（本番リリース後）
+
+本番リリース済のため Git Flow ベースの 2 段階デプロイ:
+
+```
+feature/* / chore/* / fix/*  ← develop から切る
+        ↓ PR (base: develop)
+     develop  ── push で sfscrim-dev.sf6.workers.dev に自動デプロイ
+        ↓ PR (base: main, 本番反映タイミングで人間が判断)
+       main   ── push で sfscrim.sf6.workers.dev = 本番に自動デプロイ
+```
+
+- **ship-loop の base は常に `develop`**。`gh pr create --base develop` を使う
+- 本番反映は別途 `gh pr create --base main --head develop --title "release: ..."` を人間が立てる
+- 本番 D1: `sfscrim-db` / 開発 D1: `sfscrim-db-dev`（独立、データ汚染なし）
+
 > ⚠️ ユーザー個人の汎用 `/ship` skill（PR 作成までで停止する別物）と区別するため、本プロジェクトでは **`/ship-loop`** を使う。`/ship` を呼ぶと個人版が起動して merge → 次 issue checkout まで進まないので注意。
 
 ### `/ship-loop` の流れ
@@ -48,7 +64,7 @@
 1. **Skill `/review` を使わない**。Bash で `gh pr view <PR>` + `gh pr diff <PR>` を取得して、**メインターン内で self-review** する
 2. **マーカー発行は Write tool**（Bash の `>` redirect は権限プロンプトで止まりやすい）。`.claude/settings.local.json` の `permissions.allow` に `Write(.claude/.simplify-done)` / `Write(.claude/.review-approved)` を入れて always allow にしておく
 3. **判定後（APPROVED でも指摘ありでも）テキスト応答を返さず即座に次の tool 呼び出しを実行**
-   - APPROVED → 即 Write tool で `.review-approved` → `gh pr merge` → main 同期 → 次 issue checkout
+   - APPROVED → 即 Write tool で `.review-approved` → `gh pr merge` → develop 同期 → 次 issue checkout
    - 指摘あり → 即 Edit/Write で修正 → `git commit & push` → 再 self-review
 
 詳細は `.claude/commands/ship-loop.md` を参照。
@@ -56,7 +72,7 @@
 ### 二段防御
 
 - **ローカル層**: hook がマーカー検証 → `gh pr create/merge` を制御
-- **GitHub 層**: `main` ブランチ保護で **CI（lint / typecheck / build）必須** → CI 落ちたらマージ不可
+- **GitHub 層**: `main` / `develop` ブランチ保護で **CI（lint / typecheck / build）必須** → CI 落ちたらマージ不可
 
 `.github/workflows/ci.yml` が PR ごとに 3 ジョブを走らせる：
 - `lint` (`pnpm lint`)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,12 +16,22 @@ GitHub PR open    ──▶ .github/workflows/deploy.yml
                                                                           └─ PR にコメントで preview URL 通知
 ```
 
-| ジョブ | トリガー | 動作 |
-|---|---|---|
-| `deploy-prod` | `push` to `main` | `pnpm exec opennextjs-cloudflare build` → `wrangler deploy` |
-| `deploy-preview` | `pull_request` | 上記 build → `wrangler versions upload` → preview URL を PR にコメント |
+| ジョブ | トリガー | 動作 | デプロイ先 |
+|---|---|---|---|
+| `deploy-prod` | `push` to `main` | `pnpm exec opennextjs-cloudflare build` → `wrangler deploy` | `sfscrim.sf6.workers.dev` (本番) |
+| `deploy-dev` | `push` to `develop` | 同上 → `wrangler deploy --env development` | `sfscrim-dev.sf6.workers.dev` (開発環境) |
+| `deploy-preview` | `pull_request` | 上記 build → `wrangler versions upload` → preview URL を PR にコメント | preview URL (一時) |
 
-両ジョブとも **`vars.DEPLOY_ENABLED == 'true'`** が無いとスキップされます（ガード）。
+全ジョブとも **`vars.DEPLOY_ENABLED == 'true'`** が無いとスキップされます（ガード）。
+
+### 環境隔離
+
+| 環境 | Worker name | D1 database_name | D1 UUID |
+|---|---|---|---|
+| 本番 (main) | `sfscrim` | `sfscrim-db` | `9f54f5e0-e01d-44c6-a063-62320a76fd0e` |
+| 開発 (develop) | `sfscrim-dev` | `sfscrim-db-dev` | `62f2fb9a-f04b-4723-9edc-f2b438daf380` |
+
+本番 D1 と開発 D1 は完全に独立しており、開発環境での操作は本番データに影響しません。
 
 ---
 
@@ -84,6 +94,12 @@ pnpm wrangler d1 create sfscrim-db
 
 ```bash
 pnpm db:migrate:prod
+```
+
+開発環境の D1 (`sfscrim-db-dev`) には:
+
+```bash
+pnpm db:migrate:dev
 ```
 
 ### 5. 初回デプロイ確認

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
-    "db:migrate:dev": "wrangler d1 migrations apply sfscrim-db --local",
+    "db:migrate:local": "wrangler d1 migrations apply sfscrim-db --local",
+    "db:migrate:dev": "wrangler d1 migrations apply sfscrim-db-dev --remote --env development",
     "db:migrate:prod": "wrangler d1 migrations apply sfscrim-db --remote",
-    "db:execute:dev": "wrangler d1 execute sfscrim-db --local"
+    "db:execute:local": "wrangler d1 execute sfscrim-db --local"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.19.4",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,7 @@
   "observability": {
     "enabled": true
   },
-  // Cloudflare D1 (SQLite) binding.
+  // Cloudflare D1 (SQLite) binding — production.
   // ローカルは `--local` で .wrangler/state/v3/d1 配下の SQLite を使う。
   // 本番 ID は `wrangler d1 create sfscrim-db` で発行済（APAC region）。
   "d1_databases": [
@@ -24,5 +24,25 @@
   ],
   "vars": {
     "APP_ENV": "production"
+  },
+  // Cloudflare Workers の environment 機能で開発環境を分離。
+  // `wrangler deploy --env development` で sfscrim-dev worker としてデプロイされ、
+  // https://sfscrim-dev.sf6.workers.dev で配信される。
+  // 本番 D1 とは別の sfscrim-db-dev に向ける（本番データ保護）。
+  "env": {
+    "development": {
+      "name": "sfscrim-dev",
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "sfscrim-db-dev",
+          "database_id": "62f2fb9a-f04b-4723-9edc-f2b438daf380",
+          "migrations_dir": "migrations"
+        }
+      ],
+      "vars": {
+        "APP_ENV": "development"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
本番リリース済のため Git Flow ベースの 2 段階デプロイに切替。

\`\`\`
feature/* / chore/* / fix/*  ← develop から切る
        ↓ PR (base: develop)
     develop  ── push で sfscrim-dev.sf6.workers.dev に自動デプロイ
        ↓ PR (base: main, 本番反映タイミングで人間が判断)
       main   ── push で sfscrim.sf6.workers.dev (本番) に自動デプロイ
\`\`\`

> 本 PR は base: main の最後の直接 PR です。merge 後は \`develop\` を派生して、以降の feature PR は base: develop で運用。

## 変更
- **wrangler.jsonc**: \`env.development\` を追加 (sfscrim-dev worker + sfscrim-db-dev D1 binding)
- **deploy.yml**: \`deploy-dev\` ジョブを追加 (develop push で \`wrangler deploy --env development\`)、\`deploy-prod\` は不変
- **package.json**: scripts 整理 (\`db:migrate:local\` / \`db:migrate:dev\` / \`db:migrate:prod\`)
- **ship-loop.md / CLAUDE.md**: ブランチ運用と Step 9 の develop 同期を反映
- **docs/deployment.md**: 環境表 + dev migration 手順を追記

## 環境隔離

| 環境 | Worker | D1 database | D1 UUID |
|---|---|---|---|
| 本番 (main) | \`sfscrim\` | \`sfscrim-db\` | \`9f54f5e0-e01d-44c6-a063-62320a76fd0e\` |
| 開発 (develop) | \`sfscrim-dev\` | \`sfscrim-db-dev\` | \`62f2fb9a-f04b-4723-9edc-f2b438daf380\` |

本番 D1 と開発 D1 は完全独立、開発環境での操作は本番データに影響なし。

## 事前準備済 (Cloudflare 側)
- \`sfscrim-db-dev\` D1 作成済 (APAC region)
- \`0001_init.sql\` 適用済 (\`pnpm db:migrate:dev\` で実行)
- 既存 \`CLOUDFLARE_API_TOKEN\` / \`CLOUDFLARE_ACCOUNT_ID\` を流用 (権限: Workers Scripts:Edit + D1:Edit)

## merge 後の手動作業
1. main から develop ブランチを派生して push:
   \`\`\`bash
   git checkout main && git pull
   git push origin main:develop
   \`\`\`
2. (任意) develop に branch protection (lint/typecheck/build 必須) を設定
3. 既存 open PR (\`#9\` 等) は base を develop に切り替え or 一旦閉じて develop ベースで作り直し

## Test plan
- [x] \`pnpm lint\` 通過
- [x] \`pnpm typecheck\` 通過
- [x] \`pnpm build\` 通過
- [x] \`sfscrim-db-dev\` 作成 + migration 適用 確認
- [ ] (merge 後) develop ブランチ作成 → push → \`deploy-dev\` ジョブ green 確認
- [ ] (merge 後) sfscrim-dev.sf6.workers.dev で実画面確認