### PR TITLE
chore: noindex dev environment via robots / sitemap / meta (#53)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,7 +10,7 @@ import {
   OG_LOCALE,
   type Locale,
 } from "@/i18n/routing";
-import { SITE } from "@/config/site";
+import { SITE, isDevEnv } from "@/config/site";
 import "../globals.css";
 
 const bricolage = Bricolage_Grotesque({
@@ -42,6 +42,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "Meta" });
   const canonical = localeHref(locale);
   const ogLocale = OG_LOCALE[locale as Locale] ?? OG_LOCALE[routing.defaultLocale];
+  const dev = await isDevEnv();
 
   return {
     metadataBase: METADATA_BASE,
@@ -51,6 +52,7 @@ export async function generateMetadata({
     },
     description: t("description"),
     applicationName: t("siteName"),
+    ...(dev ? { robots: { index: false, follow: false } } : {}),
     alternates: {
       canonical,
       languages: LANGUAGES,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,14 @@
 import type { MetadataRoute } from "next";
-import { SITE } from "@/config/site";
+import { SITE, isDevEnv } from "@/config/site";
 
-export default function robots(): MetadataRoute.Robots {
+export const dynamic = "force-dynamic";
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  if (await isDevEnv()) {
+    return {
+      rules: { userAgent: "*", disallow: "/" },
+    };
+  }
   return {
     rules: [
       {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,14 @@
 import type { MetadataRoute } from "next";
 import { buildLanguageAlternates } from "@/i18n/routing";
-import { SITE } from "@/config/site";
+import { SITE, isDevEnv } from "@/config/site";
+
+export const dynamic = "force-dynamic";
 
 const LAST_MODIFIED = "2026-04-28";
 const LANGUAGES = buildLanguageAlternates(SITE.url);
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  if (await isDevEnv()) return [];
   return [
     {
       url: `${SITE.url}/`,

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,6 +1,34 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
 export const SITE = {
   url: "https://sfscrim.sf6.workers.dev",
   ogImagePath: "/og-image.png",
   ogImageWidth: 1200,
   ogImageHeight: 630,
 } as const;
+
+let cachedIsDev: boolean | undefined;
+
+export async function isDevEnv(): Promise<boolean> {
+  if (cachedIsDev !== undefined) return cachedIsDev;
+  cachedIsDev = await detectIsDev();
+  return cachedIsDev;
+}
+
+async function detectIsDev(): Promise<boolean> {
+  // Fail-open by design: the [locale] layout is SSG-prerendered, so this runs
+  // at build time *with no Cloudflare context*. A single build artifact ships
+  // to both prod and dev workers, so we must not bake noindex into the HTML
+  // at build time. Dev's noindex protection comes from robots.ts (dynamic) and
+  // from generateMetadata on dynamic routes — both of which run on the dev
+  // worker at request time, where getCloudflareContext does resolve.
+  const fromProcess = process.env.APP_ENV;
+  if (fromProcess === "development") return true;
+  if (fromProcess === "production") return false;
+  try {
+    const { env } = await getCloudflareContext();
+    return env.APP_ENV === "development";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

closes #53

\`sfscrim-dev.sf6.workers.dev\` を検索エンジンから除外。\`sfscrim.sf6.workers.dev\` (本番) は従来通り。

### 変更内容

- **\`src/config/site.ts\`**: \`isDevEnv()\` ヘルパー追加
  - 優先順位: \`process.env.APP_ENV\` (ローカル override) → \`getCloudflareContext().env.APP_ENV\` (Workers ランタイム) → \`false\`
  - Workers isolate 内で APP_ENV は変わらないため module-level memoization
- **\`src/app/robots.ts\`**: \`force-dynamic\` + async
  - dev: \`{ userAgent: \"*\", disallow: \"/\" }\` のみ
  - prod: 既存挙動 (\`/scrim/\` のみ disallow + sitemap + host)
- **\`src/app/sitemap.ts\`**: \`force-dynamic\` + async
  - dev: \`[]\` (空 urlset)
  - prod: 既存挙動
- **\`src/app/[locale]/layout.tsx\`**: \`generateMetadata\` で dev 時 \`robots: { index: false, follow: false }\` を spread

### 設計判断: fail-open at build time

\`[locale]\` LP は SSG (\`●\`) で build 時に generateMetadata が呼ばれる。**1 つのビルド成果物が prod / dev 両方の Worker にデプロイされる**ため、build 時点で noindex を焼き込んではならない (= fail-open)。

dev 環境の保護:
- \`robots.txt\` (dynamic, ランタイム検出) ✓
- \`sitemap.xml\` (dynamic, ランタイム検出) ✓
- 動的ルート (\`scrim/*\`) の \`generateMetadata\` (per-request 実行) ✓

SSG'd LP HTML 自体には noindex meta は焼き込まれないが、上記 3 つで十分なクロール抑制になる。詳細は site.ts のコメント参照。

## 動作確認

\`\`\`
$ APP_ENV=development pnpm dev
$ curl /robots.txt    # → User-Agent: *  Disallow: /
$ curl /sitemap.xml   # → 空 urlset
$ curl / | grep robots  # → <meta name=\"robots\" content=\"noindex, nofollow\"/>

$ pnpm dev            # APP_ENV 未設定 (wrangler 上位 vars = production)
$ curl /robots.txt    # → 従来の prod 設定
$ curl /sitemap.xml   # → 従来の prod 設定
$ curl / | grep robots  # → なし (noindex なし)
\`\`\`

## 受け入れ条件への対応

- [x] dev 環境の \`/robots.txt\` が \`Disallow: /\` を返す
- [x] dev 環境の HTML head に \`<meta name=\"robots\" content=\"noindex, nofollow\">\` が含まれる (動的ルート分)
- [x] 本番の \`/robots.txt\` は従来通り (\`Allow: /\` + \`/scrim/\` のみ disallow)
- [x] 本番の HTML head に noindex が入らない
- [ ] (任意) dev の canonical / OGP URL が本番を指していない — 今回スコープ外。本番 URL 共有のメリット (dev 環境からのリンクシェアでも本番 OGP を見せる) を取った

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm build\` 通過
- [x] dev (\`APP_ENV=development\`) で robots / sitemap / meta が全て noindex 系
- [x] prod (デフォルト) で従来挙動を維持
- [ ] develop マージ後、\`sfscrim-dev.sf6.workers.dev/robots.txt\` を実機確認