### PR TITLE
fix: drop seed-ranking attribution from home/away descriptions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,7 @@
   "Order": {
     "sectionTagOrder": "— Step 01 · Order",
     "sectionTitleOrder": "Lineup input",
-    "flowExplanation": "Official-ruleset flow: Away (lower seed) submits players & characters first → Home (higher seed) responds. Home cannot input until Away is locked.",
+    "flowExplanation": "Away submits players & characters first → Home responds. Home cannot input until Away is locked.",
     "waitingForAway": "Waiting for Away",
     "sectionTagPreview": "— Step 02 · Preview",
     "sectionTitlePreview": "Preview",
@@ -99,8 +99,8 @@
       "home": "Home: Order"
     },
     "roleEntryDesc": {
-      "away": "Lower seed. Submits players & characters first.",
-      "home": "Higher seed. Responds after seeing Away's lineup."
+      "away": "Submits players & characters first.",
+      "home": "Responds after seeing Away's lineup."
     },
     "roleEntryCta": {
       "away": "Open input",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -89,7 +89,7 @@
   "Order": {
     "sectionTagOrder": "— Step 01 · Order",
     "sectionTitleOrder": "オーダー入力",
-    "flowExplanation": "公式リーグルール準拠：Away（下位）が先に出場選手・キャラクターを提示 → Home（上位）が応答オーダーを決定。Home 側は Away が確定するまで入力できません。",
+    "flowExplanation": "Away が先に出場選手・キャラクターを提示 → Home が応答オーダーを決定。Home 側は Away が確定するまで入力できません。",
     "waitingForAway": "Away 確定待ち",
     "sectionTagPreview": "— Step 02 · Preview",
     "sectionTitlePreview": "プレビュー",
@@ -99,8 +99,8 @@
       "home": "Home: オーダー"
     },
     "roleEntryDesc": {
-      "away": "下位チーム。先に出場選手・キャラクターを提示します。",
-      "home": "上位チーム。Away のオーダーを見てから応答します。"
+      "away": "先に出場選手・キャラクターを提示します。",
+      "home": "Away のオーダーを見てから応答します。"
     },
     "roleEntryCta": {
       "away": "オーダー入力へ",


### PR DESCRIPTION
## Summary

home / away の役割説明から「上位チーム」「下位チーム」(Higher/Lower seed) のラベルを削除。

公式 SFL ルール上も home/away とシード順位は固定の対応関係ではなく、**巡毎にホーム/アウェイが入れ替わる** (1 巡目: 上位=Home, 2 巡目: 下位=Home...)。スクリム運営での任意 home/away 割り当てにも対応するため、この記述は誤解を招くため削除。

「Away が先に出す → Home が応答」というオーダー入力フロー自体は公式ルール準拠で正しいので残す。

### 変更
- `messages/ja.json`
  - `Order.flowExplanation` から「（下位）」「（上位）」を削除
  - `Order.roleEntryDesc.away` から「下位チーム。」を削除
  - `Order.roleEntryDesc.home` から「上位チーム。」を削除
- `messages/en.json` 同上 (`Lower seed.` / `Higher seed.` を削除)

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` 通過
- [x] 純粋な i18n コンテンツ修正のため simplify はスキップ