### PR TITLE
feat: add per-position commit state to ScrimState (#60)

### DIFF
--- a/src/config/sfl-rules.ts
+++ b/src/config/sfl-rules.ts
@@ -19,6 +19,12 @@ export const SFL_RULES = {
 // 通常バトルの 3 ポジション（先鋒・中堅・大将）
 export type BattlePosition = "vanguard" | "midfield" | "champion";
 
+export const BATTLE_POSITIONS = [
+  "vanguard",
+  "midfield",
+  "champion",
+] as const satisfies readonly BattlePosition[];
+
 // 選手登録用：通常 3 ポジション + 控え
 export type PlayerSlot = BattlePosition | "sub";
 

--- a/src/lib/order-state.ts
+++ b/src/lib/order-state.ts
@@ -1,4 +1,5 @@
 import type { Player, ScrimState, Side } from "@/store/scrim";
+import { BATTLE_POSITIONS, type PlayerSlot } from "@/config/sfl-rules";
 
 export const ROLES: ReadonlyArray<Side> = ["away", "home"];
 
@@ -9,10 +10,25 @@ export function isRole(value: string): value is Side {
 export const roleStorageKey = (scrimId: string): string =>
   `sfscrim:role:${scrimId}`;
 
+// committed が未指定（旧 schema）の場合は name の有無で判定する後方互換挙動
+export function isPositionCommitted(player: Player): boolean {
+  if (player.committed === true) return true;
+  if (player.committed === false) return false;
+  return player.name.trim().length > 0;
+}
+
+export function findPlayer(
+  players: Player[],
+  position: PlayerSlot,
+): Player | undefined {
+  return players.find((p) => p.position === position);
+}
+
 export function isMainBattleCommitted(players: Player[]): boolean {
-  return (["vanguard", "midfield", "champion"] as const).every((pos) =>
-    players.some((p) => p.position === pos && p.name.trim().length > 0),
-  );
+  return BATTLE_POSITIONS.every((pos) => {
+    const player = findPlayer(players, pos);
+    return player ? isPositionCommitted(player) : false;
+  });
 }
 
 export function isOrderComplete(scrim: ScrimState): boolean {

--- a/src/store/scrim.ts
+++ b/src/store/scrim.ts
@@ -16,6 +16,8 @@ export type Player = {
   position: PlayerSlot;
   characterId?: number;
   controlType?: ControlType;
+  // ホーム逐次申告フローで使用。未指定（旧 schema）は name の有無で判定する後方互換挙動
+  committed?: boolean;
 };
 
 export type Team = {
@@ -48,6 +50,9 @@ type ScrimStore = {
   setFormat: (id: string, format: FormatMode) => void;
   setTeamName: (id: string, side: Side, name: string) => void;
   setTeamPlayers: (id: string, side: Side, players: Player[]) => void;
+  commitPosition: (id: string, side: Side, position: PlayerSlot) => void;
+  uncommitPosition: (id: string, side: Side, position: PlayerSlot) => void;
+  commitAllPositions: (id: string, side: Side) => void;
   setStatus: (id: string, status: ScrimStatus) => void;
   recordMatch: (id: string, match: MatchRecord) => void;
   undoLastMatch: (id: string) => void;
@@ -113,6 +118,55 @@ export const useScrimStore = create<ScrimStore>()(
             teams: {
               ...s.teams,
               [side]: { ...s.teams[side], players },
+            },
+          })),
+        }));
+      },
+      commitPosition: (id, side, position) => {
+        set((state) => ({
+          scrims: updateScrim(state.scrims, id, (s) => ({
+            ...s,
+            teams: {
+              ...s.teams,
+              [side]: {
+                ...s.teams[side],
+                players: s.teams[side].players.map((p) =>
+                  p.position === position ? { ...p, committed: true } : p,
+                ),
+              },
+            },
+          })),
+        }));
+      },
+      uncommitPosition: (id, side, position) => {
+        set((state) => ({
+          scrims: updateScrim(state.scrims, id, (s) => ({
+            ...s,
+            teams: {
+              ...s.teams,
+              [side]: {
+                ...s.teams[side],
+                players: s.teams[side].players.map((p) =>
+                  p.position === position ? { ...p, committed: false } : p,
+                ),
+              },
+            },
+          })),
+        }));
+      },
+      commitAllPositions: (id, side) => {
+        set((state) => ({
+          scrims: updateScrim(state.scrims, id, (s) => ({
+            ...s,
+            teams: {
+              ...s.teams,
+              [side]: {
+                ...s.teams[side],
+                players: s.teams[side].players.map((p) => ({
+                  ...p,
+                  committed: true,
+                })),
+              },
             },
           })),
         }));


### PR DESCRIPTION
Closes #60

親 issue: #58 / 後続 issue: #61, #62

## やったこと

ホーム逐次申告フロー（#58）の基盤として、ScrimState の Player に **ポジション単位の確定状態** を持たせる。UI 改修は #61 で行うため、本 PR の変更で既存挙動は変わらない。

### 設計

- `Player.committed?: boolean` を **optional** で追加
- 後方互換: 未指定（旧 schema）は **name の有無で判定** する fallback
- 判定関数 `isPositionCommitted(player)`:
  - `committed === true` → 確定
  - `committed === false` → 未確定（明示的に伏せている / リセット）
  - 未指定 → `name.trim().length > 0` で判定（旧データのまま動く）

### 新アクション (zustand store)

| アクション | 用途 |
|---|---|
| `commitPosition(id, side, position)` | 該当ポジションの player を確定（ホームが先鋒だけ発表、など）|
| `uncommitPosition(id, side, position)` | 該当ポジションを未確定に戻す（誤操作リカバリ）|
| `commitAllPositions(id, side)` | 全ポジションを一括確定（アウェイの「事前一括」用） |

### その他

- `BATTLE_POSITIONS` 定数を `src/config/sfl-rules.ts` に集約（`["vanguard","midfield","champion"]` リテラルの分散を整理。CLAUDE.md の「ハードコード禁止」方針に整合）
- `findPlayer(players, position)` ヘルパーを order-state に新設

## 受け入れ条件

- [x] ScrimState の型に「ポジション単位の確定」が表現されている（`Player.committed`）
- [x] 新アクション 3 件が動作する（commitPosition / uncommitPosition / commitAllPositions）
- [x] 既存の保存済み state（旧 schema）を読んでもクラッシュしない（committed 未指定で name 判定にフォールバック）
- [x] 「先鋒だけ commit、中堅未 commit」状態が作れる（commitPosition('vanguard') + uncommitPosition('midfield')）
- [x] 既存の UI 挙動は変わらない（UI 側を触るのは派生 issue）

## Test plan

- [x] pnpm typecheck pass
- [x] pnpm lint pass
- [x] pnpm build pass
- [ ] develop 環境で既存ダッシュボードが従来通り動く（旧 schema データの hydrate 確認）