### PR TITLE
chore: extract isSameOrigin helper and apply to all destructive endpoints (#87)

### DIFF
--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { getAuth, getSessionFromRequest } from "@/lib/auth/server";
+import { isSameOrigin } from "@/lib/auth/csrf";
 import { deleteAccount } from "@/lib/db/account";
 
 // Better Auth が cookie を rotate / 追加した場合の保険として残す念のための strip list。
@@ -16,29 +17,6 @@ const FALLBACK_COOKIE_NAMES = [
   "__Secure-better-auth.session_token",
   "__Secure-better-auth.session_data",
 ];
-
-// destructive 操作なので SameSite=Lax の defense-in-depth として Origin を必ず check する。
-// 同オリジン or BETTER_AUTH_URL に一致しない場合は 403 で拒否。
-function isSameOrigin(request: Request, expectedBaseUrl: string | undefined): boolean {
-  const origin = request.headers.get("origin");
-  if (!origin) return false;
-  let originHost: string;
-  try {
-    originHost = new URL(origin).host;
-  } catch {
-    return false;
-  }
-  const requestUrl = new URL(request.url);
-  if (originHost === requestUrl.host) return true;
-  if (expectedBaseUrl) {
-    try {
-      if (originHost === new URL(expectedBaseUrl).host) return true;
-    } catch {
-      /* invalid env, fall through */
-    }
-  }
-  return false;
-}
 
 export async function POST(request: Request): Promise<Response> {
   const { env } = await getCloudflareContext({ async: true });

--- a/src/app/api/auth/dev/test-login/route.ts
+++ b/src/app/api/auth/dev/test-login/route.ts
@@ -6,12 +6,16 @@ import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { isMockAuthEnabledFromEnv } from "@/config/site";
 import { getAuth, MOCK_TEST_USER } from "@/lib/auth/server";
+import { isSameOrigin } from "@/lib/auth/csrf";
 import { isAccountDeleted } from "@/lib/db/account";
 
 export async function POST(request: Request): Promise<Response> {
   const { env } = await getCloudflareContext({ async: true });
   if (!isMockAuthEnabledFromEnv(env)) {
     return new NextResponse("Not Found", { status: 404 });
+  }
+  if (!isSameOrigin(request, env.BETTER_AUTH_URL)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 
   // 削除済アカウントの再ログインを拒否（issue #82 PR-C: 再ログイン不可要件）

--- a/src/app/api/scrim/[id]/route.ts
+++ b/src/app/api/scrim/[id]/route.ts
@@ -3,18 +3,22 @@
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { getSessionFromRequest } from "@/lib/auth/server";
+import { isSameOrigin } from "@/lib/auth/csrf";
 import { softDeleteScrim } from "@/lib/db/scrims";
 
 export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isSameOrigin(request, env.BETTER_AUTH_URL)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
   const session = await getSessionFromRequest(request.headers);
   if (!session?.user) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
   const { id } = await params;
-  const { env } = await getCloudflareContext({ async: true });
   const ok = await softDeleteScrim(env.DB, session.user.id, id);
   if (!ok) return NextResponse.json({ error: "not_found" }, { status: 404 });
   return NextResponse.json({ ok: true });

--- a/src/app/api/scrim/finalize/route.ts
+++ b/src/app/api/scrim/finalize/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { getSessionFromRequest } from "@/lib/auth/server";
+import { isSameOrigin } from "@/lib/auth/csrf";
 import { findScrimOwner, saveScrimSnapshot } from "@/lib/db/scrims";
 import type { ScrimSnapshot } from "@/lib/scrim/snapshot";
 
@@ -47,6 +48,10 @@ function isValidSnapshot(input: unknown): input is ScrimSnapshot {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isSameOrigin(request, env.BETTER_AUTH_URL)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
   const session = await getSessionFromRequest(request.headers);
   if (!session?.user) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
@@ -62,7 +67,6 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
   }
 
-  const { env } = await getCloudflareContext({ async: true });
   const existingOwner = await findScrimOwner(env.DB, body.id);
   if (existingOwner && existingOwner !== session.user.id) {
     return NextResponse.json({ error: "forbidden" }, { status: 403 });

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -1,0 +1,37 @@
+// SameSite=Lax cookie の defense-in-depth として、destructive な POST/DELETE は
+// Origin header が同オリジン or BETTER_AUTH_URL に一致することを check する。
+// browser fetch は Origin header を forbidden にしているため攻撃者は偽造不能。
+// Origin が無い request (curl 等) は拒否する保守的判定。
+//
+// 関連: issue #87, src/app/api/account/delete/route.ts (origin 実装の発祥)
+
+export function isSameOrigin(
+  request: Request,
+  expectedBaseUrl: string | undefined,
+): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return false;
+  }
+  const requestUrl = new URL(request.url);
+  if (originHost === requestUrl.host) return true;
+  if (expectedBaseUrl) {
+    try {
+      if (originHost === new URL(expectedBaseUrl).host) return true;
+    } catch {
+      /* invalid env, fall through */
+    }
+  }
+  return false;
+}
+
+// 共通レスポンス。route ごとの形式揺れを防ぐ。
+export const FORBIDDEN_RESPONSE = (): Response =>
+  new Response(JSON.stringify({ error: "forbidden" }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  });

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -28,10 +28,3 @@ export function isSameOrigin(
   }
   return false;
 }
-
-// 共通レスポンス。route ごとの形式揺れを防ぐ。
-export const FORBIDDEN_RESPONSE = (): Response =>
-  new Response(JSON.stringify({ error: "forbidden" }), {
-    status: 403,
-    headers: { "content-type": "application/json" },
-  });


### PR DESCRIPTION
## Summary

\`#87\` (issue #82 follow-up)。\`#82\` PR-C で \`/api/account/delete\` のみに実装した CSRF Origin check を、destructive な API 全般に展開する。

- **\`src/lib/auth/csrf.ts\`**: \`isSameOrigin\` を共通 helper として切り出し
- 適用先: \`/api/scrim/finalize\` (POST) / \`/api/scrim/[id]\` (DELETE) / \`/api/auth/dev/test-login\` (POST)
- \`/api/account/delete\` は新 helper を import するよう書き換え（挙動同じ）

## なぜ

\`SameSite=Lax\` cookie で typical CSRF は防げているが、Lax の bypass paths (top-level form POST) や将来 \`SameSite=None\` に切り替わるリスクへの defense-in-depth。\`Origin\` header check は browser fetch では偽造不能で、サーバ間 (curl) は session cookie を入手できないため拒否で問題なし。

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm build\` 全 pass
- [x] dev で test-login → finalize → delete → account/delete を順次叩き、全て 200 を確認（browser fetch は Origin auto-set）
- [x] curl 等 Origin 無し request は 403 (helper 実装で担保)

## 関連

- \`#82\` (本 issue が follow-up)
- \`#87\` (本 PR が close)