### PR TITLE
chore: dedupe scrim auto-sync via lastSyncedAt persisted flag (#90)

### DIFF
--- a/src/app/[locale]/scrim/[id]/match-scoring.tsx
+++ b/src/app/[locale]/scrim/[id]/match-scoring.tsx
@@ -33,9 +33,11 @@ export function RegularSeasonScoring({ scrim }: { scrim: ScrimState }) {
   const recordMatch = useScrimStore((s) => s.recordMatch);
   const undoLast = useScrimStore((s) => s.undoLastMatch);
   const setStatus = useScrimStore((s) => s.setStatus);
+  const markSynced = useScrimStore((s) => s.markSynced);
   const { data: session } = useSession();
   const [finalizeOutcome, setFinalizeOutcome] = useState<FinalizeOutcome | null>(null);
   const [savePending, setSavePending] = useState(false);
+  const autoSyncedRef = useRef(false);
 
   const next = nextRegularBattle(scrim.matches);
   const outcome = regularSeasonOutcome(scrim);
@@ -75,7 +77,12 @@ export function RegularSeasonScoring({ scrim }: { scrim: ScrimState }) {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(serializeScrim(state)),
       });
-      setFinalizeOutcome(res.ok ? { kind: "saved" } : { kind: "save-failed" });
+      if (res.ok) {
+        markSynced(state.id, Math.floor(Date.now() / 1000));
+        setFinalizeOutcome({ kind: "saved" });
+      } else {
+        setFinalizeOutcome({ kind: "save-failed" });
+      }
     } catch {
       setFinalizeOutcome({ kind: "save-failed" });
     } finally {
@@ -84,9 +91,13 @@ export function RegularSeasonScoring({ scrim }: { scrim: ScrimState }) {
   };
 
   const onFinalize = async () => {
+    // 手動 finalize と auto-sync の二重 POST を防ぐためフラグを先に立てる
+    autoSyncedRef.current = true;
     setStatus(scrim.id, "finished");
     if (!session?.user) {
       setFinalizeOutcome({ kind: "signin-required" });
+      // 未ログインのまま終わるなら、後でログインしたとき自動同期させたいので解除
+      autoSyncedRef.current = false;
       return;
     }
     await trySave({ ...scrim, status: "finished" });
@@ -99,14 +110,12 @@ export function RegularSeasonScoring({ scrim }: { scrim: ScrimState }) {
 
   // ログアウト中に finalize して localStorage に finished のまま残った scrim を、
   // 後でログイン直後に自動で D1 へ同期する（finalize は idempotent な UPSERT）。
-  // ref は mount スコープのため、scrim/[id] 再訪問のたびに 1 回 POST が走る。
-  // 副作用は idempotent UPSERT なので無害だが、頻発するなら zustand に
-  // `lastSyncedAt` を持たせて二重発火を抑止する余地あり（後続 issue 候補）。
-  const autoSyncedRef = useRef(false);
+  // `scrim.lastSyncedAt` (zustand persist) で同期済みフラグを保持し、ナビゲートで
+  // mount しなおしても重複 POST しない。recordMatch / undoLastMatch でリセットされる。
   const userId = session?.user?.id;
+  const needsSync = scrim.status === "finished" && !!userId && !scrim.lastSyncedAt;
   useEffect(() => {
-    if (autoSyncedRef.current) return;
-    if (scrim.status !== "finished" || !userId) return;
+    if (autoSyncedRef.current || !needsSync) return;
     autoSyncedRef.current = true;
     // setState を effect 同期で呼ばない（react-hooks/set-state-in-effect 回避）。
     // microtask に流して mount 直後の render commit 後に走らせる。
@@ -115,7 +124,7 @@ export function RegularSeasonScoring({ scrim }: { scrim: ScrimState }) {
     });
     // trySave は最新 scrim を closure で参照する。trySave は依存追跡しない。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrim.status, userId]);
+  }, [needsSync]);
 
   return (
     <section className="mt-12">

--- a/src/store/scrim.ts
+++ b/src/store/scrim.ts
@@ -42,6 +42,9 @@ export type ScrimState = {
   matches: MatchRecord[];
   status: ScrimStatus;
   createdAt: string;
+  // D1 cloud snapshot に同期した最終時刻 (Unix sec)。auto-sync の二重発火抑止に使う。
+  // undo 等で in_progress に戻った場合、再 finalize 時に updateScrim を経由してリセット。
+  lastSyncedAt?: number;
 };
 
 type ScrimStore = {
@@ -56,6 +59,7 @@ type ScrimStore = {
   setStatus: (id: string, status: ScrimStatus) => void;
   recordMatch: (id: string, match: MatchRecord) => void;
   undoLastMatch: (id: string) => void;
+  markSynced: (id: string, syncedAt: number) => void;
   reset: (id: string) => void;
   hasScrim: (id: string) => boolean;
   getScrim: (id: string) => ScrimState | undefined;
@@ -228,7 +232,8 @@ export const useScrimStore = create<ScrimStore>()(
               (m) => m.roundNo === match.roundNo && m.position === match.position,
             );
             if (dup) return s;
-            return { ...s, matches: [...s.matches, match] };
+            // 試合結果が変わったら lastSyncedAt は無効化（次の finalize で再 sync）
+            return { ...s, matches: [...s.matches, match], lastSyncedAt: undefined };
           }),
         }));
       },
@@ -237,8 +242,15 @@ export const useScrimStore = create<ScrimStore>()(
           scrims: updateScrim(state.scrims, id, (s) => ({
             ...s,
             matches: s.matches.slice(0, -1),
+            // 試合結果が変わったら lastSyncedAt は無効化
+            lastSyncedAt: undefined,
             // status を draft/in_progress に戻すかは workspace 側で判断
           })),
+        }));
+      },
+      markSynced: (id, syncedAt) => {
+        set((state) => ({
+          scrims: updateScrim(state.scrims, id, (s) => ({ ...s, lastSyncedAt: syncedAt })),
         }));
       },
       reset: (id) => {


### PR DESCRIPTION
## Summary

\`#90\` (issue #82 follow-up)。\`#82\` PR-B の auto-sync は mount スコープの \`useRef\` だけで重複抑止していたため、\`/scrim/[id]\` を再訪問するたびに idempotent UPSERT が走っていた（D1 write コスト無駄）。zustand persist で \`lastSyncedAt\` を保持して二重発火を抑止する。

- **\`src/store/scrim.ts\`**: \`ScrimState.lastSyncedAt: number | undefined\` (Unix sec) を追加
- **\`recordMatch\` / \`undoLastMatch\`**: 試合結果が変わったら \`lastSyncedAt\` を undefined にリセット → 再 finalize で再 sync
- **\`markSynced\` action 追加**: \`trySave\` 成功時に呼ぶ
- **auto-sync \`useEffect\`**: 発火条件に \`!scrim.lastSyncedAt\` を追加
- **\`onFinalize\` 開始時に \`autoSyncedRef.current = true\` を先に立てる**: 手動 finalize と auto-sync の同 mount 内二重 POST を防ぐ

## 動作確認

dev で:
1. in_progress scrim を localStorage に inject → /scrim/[id] へ navigate
2. finalize ボタンクリック → POST /api/scrim/finalize 1 回のみ (auto-sync は autoSyncedRef で抑止)
3. /history → /scrim/[id] と再 navigate しても POST 増えない (lastSyncedAt セット済)

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm build\` 全 pass
- [x] dev で finalize → POST 1 回 → 再 navigate しても再 POST しないこと grep で確認
- [x] localStorage に \`lastSyncedAt\` (Unix sec) が保存されていること

## 関連

- \`#82\` (本 issue が follow-up)
- \`#90\` (本 PR が close)